### PR TITLE
Make hooks funcallable.

### DIFF
--- a/nhooks.asd
+++ b/nhooks.asd
@@ -6,7 +6,7 @@
   :description "Improved hooks facility inspired by Serapeum."
   :author "Qiantan Hong <qhong@alum.mit.edu>"
   :license "MIT"
-  :depends-on ("serapeum")
+  :depends-on ("serapeum" "closer-mop")
   :in-order-to ((test-op (test-op "nhooks/tests")))
   :components ((:file "package")
                (:file "nhooks")))

--- a/nhooks.lisp
+++ b/nhooks.lisp
@@ -75,7 +75,9 @@ Detail: ~a" function ftype c))))
   (values))
 
 (defmethod initialize-instance :after ((handler handler) &key &allow-other-keys)
-  (closer-mop:set-funcallable-instance-function handler (fn handler))
+  (closer-mop:set-funcallable-instance-function
+   handler (lambda (&rest args)
+             (apply (fn handler) args)))
   (with-slots (name fn) handler
     (setf name (or name (name fn)))
     (unless name

--- a/nhooks.lisp
+++ b/nhooks.lisp
@@ -253,6 +253,9 @@ handlers-alist."
     (handlers-alist hook)))
 
 (defmethod run-hook ((hook hook) &rest args)
+  "Invoke all the HOOK handlers with the default `combination'.
+
+Alternatively, use `funcall' of the hook for the same effect."
   (let ((*hook* hook))
     (apply (combination hook) hook args)))
 

--- a/nhooks.lisp
+++ b/nhooks.lisp
@@ -136,12 +136,14 @@ removing them from the hook.")
                 :initform #'default-combine-hook
                 :documentation "
 This can be used to reverse the execution order, return a single value, etc."))
+  (:metaclass closer-mop:funcallable-standard-class)
   (:documentation "This hook class serves as support for typed-hook.
 
 Typing in hook is crucial to guarantee that a hook is well formed, i.e. that
 its handlers accept the right argument types and return the right value types."))
 
 (defmethod initialize-instance :after ((hook hook) &key handlers disabled-handlers &allow-other-keys)
+  (closer-mop:set-funcallable-instance-function hook (alexandria:curry #'run-hook hook))
   (setf (handlers-alist hook)
         (append (mapcar (alexandria:rcurry #'cons t) handlers)
                 (mapcar (alexandria:rcurry #'cons nil) disabled-handlers)
@@ -331,7 +333,8 @@ type, so that all hooks of such class have the same `handler-type'."
   (let* ((name (string name))
          (hook-class-name (intern (serapeum:concat "HOOK-" name))))
     `(defclass ,hook-class-name (hook)
-       ((handler-type :initform ',type :allocation :class)))))
+       ((handler-type :initform ',type :allocation :class))
+       (:metaclass closer-mop:funcallable-standard-class))))
 
 ;; TODO: Allow listing all the hooks?
 


### PR DESCRIPTION
This makes hooks `funcall`-able. Not much practical value, except allowing for more relaxed hook invocations, compared to the regular `nhooks:run-hook`.

This adds a `closer-mop` dependency, which might be problematic for other projects (potentially) relying on this library, but it's fine for Nyxt—it already depends on `closer-mop` :)

As an additional mind-boggling thing: SBCL allows [extending `sequence` class](http://www.sbcl.org/manual/index.html#Extensible-Sequences) to allow for any class to behave like sequences. Maybe implement this too, indexing handlers etc...

Does that look sane?