### PR TITLE
nhooks.lisp: Fix append behaviour.

### DIFF
--- a/nhooks.lisp
+++ b/nhooks.lisp
@@ -89,9 +89,9 @@ Handlers are equal if they are setters of the same place and same value, or if
 their names are equal."
   (cond
     ((or (and (place fn1)
-              (not (place fn2) ))
+              (not (place fn2)))
          (and (place fn2)
-              (not (place fn1) )))
+              (not (place fn1))))
      nil)
     ((and (place fn1)
           (place fn2))
@@ -202,8 +202,8 @@ This is an acceptable `combination' for `hook'."
             do (let ((res (with-disable-handler-restart (handler)
                             (with-hook-restart
                               (apply handler args)))))
-               (push res result)
-               (unless res (return))))
+                 (push res result)
+                 (unless res (return))))
     (nreverse result)))
 
 (defmethod combine-hook-until-success ((hook hook) &rest args)
@@ -246,7 +246,7 @@ non-nil) of `handler-alist' and ensure it is enabled."
     (alexandria:when-let ((old-handler (assoc handler (handlers-alist hook) :test #'equals)))
       (remove-hook hook (first old-handler)))
     (if append
-        (alexandria:appendf (symbol-value hook) (list (cons handler t)))
+        (alexandria:appendf (handlers-alist hook) (list (cons handler t)))
         (push (cons handler t) (handlers-alist hook)))
     hook))
 


### PR DESCRIPTION
Using the `nhooks` system from quicklisp there is a bug while using the `:append` key on `add-hook`. My use case depends on preserving the order handlers are added to hooks.

Before the patch, using add-hooks without `:append` works as intended:

```lisp
CL-USER> (progn
           (defun bar () (print "Running bar"))
           (defun foo () (print "Running foo"))
           (let ((foo-hook (make-instance 'nhooks:hook)))
             (nhooks:add-hook foo-hook 'foo)
             (nhooks:add-hook foo-hook 'bar)
             (nhooks:run-hook foo-hook)))
"Running bar"
"Running foo"
```

But using :append t results in an error:

```lisp
CL-USER> (progn
           (defun bar () (print "Running bar"))
           (defun foo () (print "Running foo"))
           (let ((foo-hook (make-instance 'nhooks:hook)))
             (nhooks:add-hook foo-hook 'foo :append t)
             (nhooks:add-hook foo-hook 'bar :append t)
             (nhooks:run-hook foo-hook)))

The value
  #<NHOOKS:HOOK {1001635CE3}>
is not of type
  SYMBOL
```

With the patch, the expected ordering occurs.

Note: the rest of the is patch basically indented code for legibility (automatic), so feel free to reject it. 
